### PR TITLE
Update opt-ipy-server.py

### DIFF
--- a/v3/opt-ipy-server.py
+++ b/v3/opt-ipy-server.py
@@ -98,7 +98,10 @@ def main():
     tornado.options.parse_command_line()
     app = Application()
     app.listen(options.port)
-    tornado.ioloop.IOLoop.instance().start()
+    try:
+        tornado.ioloop.IOLoop.instance().start()
+    except KeyboardInterrupt:
+        tornado.ioloop.IOLoop.instance().stop()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow user to close server.

Currently I can only terminate the process by terminating the task. 
With this change user can press <kbd>Ctrl+C</kbd> (or <kbd>Ctrl+Break</kbd> on Windows) to close the server.